### PR TITLE
fix(plugin): use composed path function to get the correct event target

### DIFF
--- a/OpenRPA.NativeMessagingHost/myAddon2/content.js
+++ b/OpenRPA.NativeMessagingHost/myAddon2/content.js
@@ -709,7 +709,12 @@ if (true == false) {
                         // https://stackoverflow.com/questions/3437786/get-the-size-of-the-screen-current-web-page-and-browser-window
                         let message = { functionName: action, frame: frame, parents: 0, xpaths: [] };
                         let targetElement = null;
-                        targetElement = event.target || event.srcElement;
+                        try {
+                            targetElement = event.composedPath()[0];
+                        } catch (e) {
+                            console.error('event composed path');
+                        }
+                        targetElement = targetElement || event.target || event.srcElement;
                         if (targetElement == null) {
                             console.log('targetElement == null');
                             return;

--- a/OpenRPA.NativeMessagingHost/myAddon2/content.js
+++ b/OpenRPA.NativeMessagingHost/myAddon2/content.js
@@ -709,12 +709,9 @@ if (true == false) {
                         // https://stackoverflow.com/questions/3437786/get-the-size-of-the-screen-current-web-page-and-browser-window
                         let message = { functionName: action, frame: frame, parents: 0, xpaths: [] };
                         let targetElement = null;
-                        try {
-                            targetElement = event.composedPath()[0];
-                        } catch (e) {
-                            console.error('event composed path');
-                        }
-                        targetElement = targetElement || event.target || event.srcElement;
+                       
+                        targetElement = event.isComposed ? event.composedPath()[0] : event.target || event.srcElement;
+                   
                         if (targetElement == null) {
                             console.log('targetElement == null');
                             return;


### PR DESCRIPTION
Because of shadow DOM roots, some target elements were being sent wrongly when an event was raised by the user.

Changes:
Use event.composedPath() to get the original target element instead of using event.target

Explanation:
When an event was raised from within a shadow root, the application was getting the element target as the first element right before the shadow root. (i.e event.target).
<img width="260" alt="image" src="https://github.com/IBM/openrpa/assets/50721171/d700e723-2ce7-456e-a0d3-ecf715975eee">

Using event.composedPath() allows it to get the element target from within the shadow root, which is the element that originated the event.
<img width="263" alt="image" src="https://github.com/IBM/openrpa/assets/50721171/959eb9c2-5b67-4a0b-9aa3-96cb733e19b7">

Note: composedPath() only works for composed events.
More info: https://pm.dartus.fr/blog/a-complete-guide-on-shadow-dom-and-event-propagation/#what-about-standard-events%3F
