### PR TITLE
fix(plugin): use mutation observer to add change event for shadow root elements

### DIFF
--- a/OpenRPA.NativeMessagingHost/myAddon2/content.js
+++ b/OpenRPA.NativeMessagingHost/myAddon2/content.js
@@ -432,6 +432,10 @@ if (true == false) {
                                                 const nestedShadowRoots = getAllShadowRoots(shadowRootMutation.target);
 
                                                 nestedShadowRoots.forEach((nestedRoot) => {
+                                                    nestedRoot.removeEventListener('change', (e) => {
+                                                        if (e.isTrusted) handleChange(e);
+                                                    }, true);
+                                                    
                                                     nestedRoot.addEventListener('change', (e) => {
                                                         if (e.isTrusted) handleChange(e);
                                                     }, true);

--- a/OpenRPA.NativeMessagingHost/myAddon2/content.js
+++ b/OpenRPA.NativeMessagingHost/myAddon2/content.js
@@ -318,14 +318,14 @@ if (true == false) {
 
                     MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
 
-                    let observer = new MutationObserver(function (mutations, observer) {
+                    let iframeObserver = new MutationObserver(function (mutations, observer) {
                         if (document.onmousemove == null) {
                             console.log('registered again because was not correctly registred (probably an iframe)');
                             openrpautil.init();
                         }
                     });
 
-                    observer.observe(document, {
+                    iframeObserver.observe(document, {
                         childList: true
                     });
 
@@ -417,13 +417,18 @@ if (true == false) {
                     }, true);
                     document.addEventListener('mousedown', function (e) { openrpautil.pushEvent('mousedown', e); }, true);
 
-                    const mutationObserver = new MutationObserver((mutations) => {
-                         mutations.forEach((child) =>{
+                    observersOption = {
+                        childList: true,
+                        subtree: true,
+                    };
+
+                    const shadowRootsObserver = new MutationObserver((mutations) => {
+                         mutations.forEach((child) => {
                             if (child.target.nodeType === Node.ELEMENT_NODE) {
                                 const shadowRoots = getAllShadowRoots(child.target);
 
                                  shadowRoots.forEach((root) => {
-                                    const shadowRootObserver = new MutationObserver((shadowRootMutations) => {
+                                    const nestedShadowRootObserver = new MutationObserver((shadowRootMutations) => {
                                         let prevTarget;
 
                                         shadowRootMutations.forEach((shadowRootMutation) => {
@@ -444,19 +449,13 @@ if (true == false) {
                                         });
                                     })
 
-                                    shadowRootObserver.observe(root, {
-                                        childList: true,
-                                        subtree: true,
-                                    });
+                                    nestedShadowRootObserver.observe(root, observersOption);
                                 })
                             }
                         });
                     });
 
-                    mutationObserver.observe(document, {
-                        childList: true,
-                        subtree: true,
-                    });
+                    shadowRootsObserver.observe(document, observersOption);
 
                     openrpautil.getRunningVersion();
                 },


### PR DESCRIPTION
Change event in elements within a shadow root wasn't working as expected.

Because of shadow DOM roots, when triggering the change event in an element within a shadow root, the application was getting a customEvent with the wrong target element instead of getting the actual event that occurred in that element.

Change events in elements within nested shadow roots are treated as a non-trusted and non-composed event, given the application this customEvent object with the first element right after the first shadow root as the target element. To fix this behavior, we need to add a change event in the shadow root that is wrappering the element.

<img width="284" alt="image" src="https://github.com/IBM/openrpa/assets/50721171/10971c2d-ab50-4768-a2a2-db655cfcc4a7">

The proposed solution is to use MutationObservers to add change events dynamically.
The first Observer checks for shadow roots in the whole page.

MutationObservers doesn't run the callback function when a mutation occurs within a shadow root, unless it's observing that shadow root specifically.
That's why it's necessary to add another Observer for the shadow roots found, in case there are nested shadow roots in the DOM.

The second Observer will then add the change event to the shadow root that is wrappering the desired element.
