### PR TITLE
fix(plugin) improve types validation for change event

### DIFF
--- a/OpenRPA.NativeMessagingHost/myAddon2/content.js
+++ b/OpenRPA.NativeMessagingHost/myAddon2/content.js
@@ -297,7 +297,7 @@ if (true == false) {
                 cKey = 67;
             var inputTypes = ['text', 'textarea', 'select', 'radio', 'checkbox', 'search', 'tel', 'url', 'number', 'range', 'email', 'password', 'date', 'month', 'week', 'time', 'datetime-local', 'month', 'color', 'file'];
             const handleChange = (e) => {
-                if (inputTypes.some(i => i === e.target.type)) {
+                if (inputTypes.some(i => e.target.type.includes(i))) {
                     openrpautil.pushEvent('change', e);
                 }
             }
@@ -776,7 +776,7 @@ if (true == false) {
                         let targetElement = null;
                        
                         targetElement = event.isComposed ? event.composedPath()[0] : event.target || event.srcElement;
-                   
+
                         if (targetElement == null) {
                             console.log('targetElement == null');
                             return;


### PR DESCRIPTION
Resolves: DBACLD-115857

Context:

The current solution used to check input type, can fail in some situations,  especially when we have custom input types. This situation was found on the site: HRM during tests.

Problem:

With the current check validation inputTypes.some(i => i === e.target.type) the TM are not able to detect change events into HTML Element of type 'select'.

Solution:

We need exchange the check validation to inputTypes.some(i => e.target.type.includes(i))