### PR TITLE
fix(plugin): use correct property for composed events

### DIFF
--- a/OpenRPA.NativeMessagingHost/myAddon2/content.js
+++ b/OpenRPA.NativeMessagingHost/myAddon2/content.js
@@ -775,7 +775,7 @@ if (true == false) {
                         let message = { functionName: action, frame: frame, parents: 0, xpaths: [] };
                         let targetElement = null;
                        
-                        targetElement = event.isComposed ? event.composedPath()[0] : event.target || event.srcElement;
+                        targetElement = event.composed ? event.composedPath()[0] : event.target || event.srcElement;
 
                         if (targetElement == null) {
                             console.log('targetElement == null');


### PR DESCRIPTION
Wrong property for checking composed events was being used.

It was using `event.isComposed` when it should be using `event.composed`.